### PR TITLE
fix: correct min/max-w/h arbitrary values

### DIFF
--- a/npm/CssToTailwindTranslator.ts
+++ b/npm/CssToTailwindTranslator.ts
@@ -1330,19 +1330,19 @@ const propertyMap: Map<string, Record<string, string> | ((val: string) => string
   ],
   [
     'max-height',
-    val => (isUnit(val) ? ({ "0px": "max-h-0", "100%": "max-h-full", "100vh": "max-h-screen" }[val] ?? `[${val}]`) : '')
+    val => (isUnit(val) ? ({ "0px": "max-h-0", "100%": "max-h-full", "100vh": "max-h-screen" }[val] ?? `max-h-[${val}]`) : '')
   ],
   [
     'max-width',
-    val => (isUnit(val) ? ({ "none": "max-w-none", "100%": "max-w-full", "min-content": "max-w-min", "max-content": "max-w-max" }[val] ?? `[${val}]`) : '')
+    val => (isUnit(val) ? ({ "none": "max-w-none", "100%": "max-w-full", "min-content": "max-w-min", "max-content": "max-w-max" }[val] ?? `max-w-[${val}]`) : '')
   ],
   [
     'min-height',
-    val => (isUnit(val) ? ({ "0px": "min-h-0", "100%": "min-h-full", "100vh": "min-h-screen" }[val] ?? `[${val}]`) : '')
+    val => (isUnit(val) ? ({ "0px": "min-h-0", "100%": "min-h-full", "100vh": "min-h-screen" }[val] ?? `min-h-[${val}]`) : '')
   ],
   [
     'min-width',
-    val => (isUnit(val) ? ({ "0px": "min-w-0", "100%": "min-w-full", "min-content": "min-w-min", "max-content": "min-w-max" }[val] ?? `[${val}]`) : '')
+    val => (isUnit(val) ? ({ "0px": "min-w-0", "100%": "min-w-full", "min-content": "min-w-min", "max-content": "min-w-max" }[val] ?? `min-w-[${val}]`) : '')
   ],
   [
     'mix-blend-mode',


### PR DESCRIPTION
# Bug Reproduction

1. Input CSS with min or max width or height that has a value not used in the Tailwind defaults.
2. The output just contains the value in brackets. It is missing `min-w`, `max-h`, etc.

<table>
<tr>
<td>Input CSS</td> <td>Output Tailwind</td>
</tr>
<tr>
<td>

```css
body {
    min-height: 24px;
    max-height: 24px;
    min-width: 24px;
    max-width: 24px;
}
```

</td>
<td>

```plaintext
[24px]
```

</td>
</tr>
</table>

# Fix

Add the correct prefix to the arbitrary value case for the configurations of

- `min-w`
- `max-w`
- `min-h`
- `max-h`