### PR TITLE
Fix rotation/rotate styles

### DIFF
--- a/npm/CssToTailwindTranslator.ts
+++ b/npm/CssToTailwindTranslator.ts
@@ -1595,8 +1595,8 @@ const propertyMap: Map<string, Record<string, string> | ((val: string) => string
     }
   ],
   [
-    'rotation',
-    val => (`[rotation:${getCustomVal(val)}]`)
+    'rotate',
+    val => (`[rotate:${getCustomVal(val)}]`)
   ],
   [
     'row-gap',


### PR DESCRIPTION
# Context

The CSS property for rotation is called `rotate` (see the [documentation](https://developer.mozilla.org/en-US/docs/Web/CSS/rotate)).

# Problem

The current code calls it `rotation`. This prevents it from detecting the CSS property in inputted code and emitting it in outputted code.

# Solution

This PR changes `rotation` to `rotate` to be in line with the CSS spec.