### PR TITLE
Remove `transform` class

### DIFF
--- a/npm/CssToTailwindTranslator.ts
+++ b/npm/CssToTailwindTranslator.ts
@@ -1886,7 +1886,7 @@ const propertyMap: Map<string, Record<string, string> | ((val: string) => string
         })
         return canUsePipeV ? pipeV : ''
       })
-      return canUse ? `transform ${[...new Set(res)].join(' ')}` : `[transform:${getCustomVal(val)}]`
+      return canUse ? `${[...new Set(res)].join(' ')}` : `[transform:${getCustomVal(val)}]`
     }
   ],
   [


### PR DESCRIPTION
# Context

The translator has code that emits the `transform` class whenever a transform property (e.g., `translate`, `rotate`, or `scale`) is detected. This is the code responsible:

```ts
return canUse ? `transform ${[...new Set(res)].join(' ')}` : `[transform:${getCustomVal(val)}]`;
```

Here is an example of the Tailwind emitted:

![Screenshot 2023-08-04 at 5 40 03 PM](https://github.com/hymhub/css-to-tailwind/assets/20476973/2563c6fa-07a9-48fd-bd53-56be3d9ebe63)

# Problem

According to the [Tailwind 2 documentation](https://v2.tailwindcss.com/docs/transform) `transform` is a class that exists in Tailwind 2. However, the [Tailwind 3 documentation](https://tailwindcss.com/docs/scale) makes no mention of this class.

Further analysis in the CSS inspector reveals that `transform` applies the same CSS that the `translate`, `rotate`, and `scale` classes do. Thus, it is not necessary.

![Screenshot 2023-08-04 at 5 45 19 PM](https://github.com/hymhub/css-to-tailwind/assets/20476973/66ac80e8-8fc3-4b3b-b8b6-850e22371212)

# Solution

We simply remove the word `transform` from the output of transform class generation.

```ts
return canUse ? `${[...new Set(res)].join(' ')}` : `[transform:${getCustomVal(val)}]`;
```